### PR TITLE
Add files for a JupyterLite demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install the dependencies
+        run: |
+          python -m pip install jupyterlite-core jupyterlite-pyodide-kernel
+
+          # install a dev version of the extension
+          python -m pip install .
+      - name: Build the JupyterLite site
+        run: |
+          jupyter lite build --output-dir dist
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered
 > It is exploring the integration of the MistralAI API with JupyterLab, which can also be used in [JupyterLite](https://jupyterlite.readthedocs.io/).
 > For a more complete AI extension for JupyterLab, see [Jupyter AI](https://github.com/jupyterlab/jupyter-ai).
 
+## ✨ Try it in your browser ✨
+
+You can try the extension in your browser using JupyterLite:
+
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jtpio.github.io/jupyterlab-codestral/lab/index.html)
+
+See the [Usage](#usage) section below for more information on how to provide your API key.
+
 ## Install
 
 To install the extension, execute:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # jupyterlab-codestral
 
 [![Github Actions Status](https://github.com/jtpio/jupyterlab-codestral/workflows/Build/badge.svg)](https://github.com/jtpio/jupyterlab-codestral/actions/workflows/build.yml)
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jtpio.github.io/jupyterlab-codestral/lab/index.html)
 
-Codestral AI code completions for JupyterLab (powered by MistralAI).
+AI code completions and chat for JupyterLab, Notebook 7 and JupyterLite, powered by MistralAI ✨
+
+[a screencast showing the Codestral extension in JupyterLite](https://github.com/jtpio/jupyterlab-codestral/assets/591645/b63a84de-32bf-449c-8b48-7d71494b88b9)
 
 ## Requirements
 


### PR DESCRIPTION
So it's easier to try it in the browser by just pasting an API key.